### PR TITLE
Fix moment.js instantiation on timestamp in ms

### DIFF
--- a/__tests__/moment_spec.re
+++ b/__tests__/moment_spec.re
@@ -61,6 +61,17 @@ let () =
             fun () =>
               expect (Moment.isSame (moment "2017-04-01") (moment "2017-04-01")) |> toBe true
           );
+        test
+          "instantiation momentWithTimestampMS (float)"
+          (
+            fun () =>
+              expect (
+                Moment.isSame
+                  (moment "2017-06-12T18:30:00+02:00")
+                  (momentWithTimestampMS (Int64.of_string "1497285000000" |> Int64.to_float))
+              ) |>
+              toBe true
+          );
         test ".now" (fun () => expect (momentNow () |> Moment.isValid) |> toBe true);
         test
           "#isSame"

--- a/src/momentRe.re
+++ b/src/momentRe.re
@@ -127,7 +127,7 @@ external momentWithFormat : string => string => Moment.t = "moment" [@@bs.module
 
 external momentWithFormats : string => list string => Moment.t = "moment" [@@bs.module];
 
-external momentWithTimestamp : int => Moment.t = "moment" [@@bs.module];
+external momentWithTimestampMS : float => Moment.t = "moment" [@@bs.module];
 
 external momentWithComponents : list int => Moment.t = "moment" [@@bs.module];
 


### PR DESCRIPTION
Timestamp in ms overflows int32.

BS int is int32 by default; BS int64 doesn't map to JS number whereas
BS float does.

See here:

http://bloomberg.github.io/bucklescript/Manual.html#_integers
http://bloomberg.github.io/bucklescript/Manual.html#_simple_ocaml_type
http://momentjs.com/docs/#/parsing/unix-timestamp-milliseconds/